### PR TITLE
chore(*) prevent lua_pack from leaking to globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Table of Contents
 
+- [0.1.3](#013---20201118)
 - [0.1.2](#012---20201105)
 - [0.1.1](#011---20200526)
 - [0.1.0](#010---20200521)
+
+##  [0.1.3] - 2020/11/18
+
+- Prevent `lua_pack` from leaking to `string`
 
 ##  [0.1.2] - 2020/11/05
 
@@ -19,6 +24,7 @@ main protoc file's directory as base for non-absolute paths
 
 - Initial release of gRPC gateway plugin for Kong.
 
+[0.1.3]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.0...0.1.1
 [0.1.0]

--- a/kong-plugin-grpc-gateway-0.1.3-1.rockspec
+++ b/kong-plugin-grpc-gateway-0.1.3-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-grpc-gateway"
 
-version = "0.1.2-1"
+version = "0.1.3-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git+https://git@github.com/Kong/kong-plugin-grpc-gateway.git",
-  tag = "0.1.2",
+  tag = "0.1.3",
 }
 
 description = {

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -1,16 +1,24 @@
 -- Copyright (c) Kong Inc. 2020
 
-package.loaded.lua_pack = nil   -- BUG: why?
-require "lua_pack"
+local bpack, bunpack
+do
+  local string_pack = string.pack     -- luacheck: ignore
+  local string_unpack = string.unpack -- luacheck: ignore
+  package.loaded.lua_pack = nil
+  require "lua_pack"
+  bpack = string.pack                 -- luacheck: ignore
+  bunpack = string.unpack             -- luacheck: ignore
+  string.unpack = string_unpack       -- luacheck: ignore
+  string.pack = string_pack           -- luacheck: ignore
+end
+
+
 local cjson = require "cjson"
 local protoc = require "protoc"
 local pb = require "pb"
 local pl_path = require "pl.path"
 
 local setmetatable = setmetatable
-
-local bpack = string.pack         -- luacheck: ignore string
-local bunpack = string.unpack     -- luacheck: ignore string
 
 local ngx = ngx
 local re_gsub = ngx.re.gsub

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -23,8 +23,6 @@ local grpc_gateway = {
   VERSION = '0.1.2',
 }
 
---require "lua_pack"
-
 
 local CORS_HEADERS = {
   ["Content-Type"] = "application/json",

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -20,7 +20,7 @@ local kong_service_request_set_raw_body = kong.service.request.set_raw_body
 
 local grpc_gateway = {
   PRIORITY = 998,
-  VERSION = '0.1.2',
+  VERSION = '0.1.3',
 }
 
 


### PR DESCRIPTION
### Summary

`lua_pack` is especially bad as it monkey patches the `string` in Lua. This means that whenever you require the `lua_pack` the `string` is modified. We don't want this to happen, thus we have this special construct there.

This also contains another commit `chore(*) release 0.1.3`.
